### PR TITLE
Fixed memory leak on timeout use

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,11 +79,11 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 		} 
 	);
 		
-		const [timeoutHandle, setTimeoutHandle] = useState(0);
-		const timeoutHandleRef = useRef(timeoutHandle);
-		timeoutHandleRef.current = timeoutHandle;
-		const [index, setIndex] = useState(0);
-		const indexRef = useRef(index);
+	const [timeoutHandle, setTimeoutHandle] = useState(0);
+	const timeoutHandleRef = useRef(timeoutHandle);
+	timeoutHandleRef.current = timeoutHandle;
+	const [index, setIndex] = useState(0);
+	const indexRef = useRef(index);
 	indexRef.current = index;
 	
 	if (callbacks) callbacks.getCount = () => imgs.length;
@@ -102,9 +102,9 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			subWrappers.push(subRef.current);
 		})
 		
-				const length = bgWrappers.length;
+		const length = bgWrappers.length;
 		const callback = function(){     
-						const index = indexRef.current;
+			const index = indexRef.current;
 			
 			bgWrappers[index].style.opacity = 0;
 			bgWrappers[(index + 1) % length].style.opacity = 1;
@@ -115,42 +115,39 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			subWrappers[(index + 1) % length].style.opacity = 1;
 			subWrappers[(index + 1) % length].style.pointerEvents = "auto";					
 			
-			if(callbacks && callbacks.onChange) 
-			{
+			if(callbacks && callbacks.onChange){
 				callbacks.onChange(index, (index + 1) % length);
 			}
-						setIndex(prevIndex => (prevIndex + 1) % length);
-						clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
+			setIndex(prevIndex => (prevIndex + 1) % length);
+			clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
 		}
 
-				clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
+		clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
  
-				if (callbacks){     
-						callbacks.atIndex = function (newIndex) {
-								const index = indexRef.current;
-								clearTimeout(timeoutHandleRef.current);
-										
-								bgWrappers[index].style.opacity = 0;
-								bgWrappers[(newIndex) % length].style.opacity = 1;
+		if (callbacks){     
+			callbacks.atIndex = function (newIndex) {
+				const index = indexRef.current;
+				clearTimeout(timeoutHandleRef.current);
+						
+				bgWrappers[index].style.opacity = 0;
+				bgWrappers[(newIndex) % length].style.opacity = 1;
+
+				subWrappers[index].style.opacity = 0;
+				subWrappers[index].style.pointerEvents = "none";
 				
-								subWrappers[index].style.opacity = 0;
-								subWrappers[index].style.pointerEvents = "none";
-								
-								subWrappers[(newIndex) % length].style.opacity = 1;
-								subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
-				
-				
-				if(callbacks.onChange) 
-				{
+				subWrappers[(newIndex) % length].style.opacity = 1;
+				subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
+		
+				if(callbacks.onChange){
 					callbacks.onChange(index, newIndex % length);
 				}
-								setIndex((newIndex) % length);
-								clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
-						}
+				setIndex((newIndex) % length);
+				clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
+			}
 
-						callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
+			callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
 			callbacks.prev = () => callbacks.atIndex((indexRef.current + length - 1) % length);
-				}
+		}
 		
 		return () => {
 			clearTimeout(timeoutHandleRef.current);

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,11 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 	
 	if (callbacks) callbacks.getCount = () => imgs.length;
 
+  const clearAndSetTimeoutHandle = (newTimeoutHandle) => {
+    clearTimeout(timeoutHandleRef.current);
+    setTimeoutHandle(newTimeoutHandle);
+  }
+
 	const initEffect = () => {
 		bgRefs.forEach((bgRef) => {
 			bgWrappers.push(bgRef.current.firstElementChild);			
@@ -115,10 +120,10 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 				callbacks.onChange(index, (index + 1) % length);
 			}
             setIndex(prevIndex => (prevIndex + 1) % length);
-            setTimeoutHandle(setTimeout(callback, duration * 1000));
+            clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
 		}
 
-        setTimeoutHandle(setTimeout(callback, initDelay * 1000));
+        clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
  
         if (callbacks){     
             callbacks.atIndex = function (newIndex) {
@@ -140,7 +145,7 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 					callbacks.onChange(index, newIndex % length);
 				}
                 setIndex((newIndex) % length);
-                setTimeoutHandle(setTimeout(callback, duration * 1000));        
+                clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
             }
 
             callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,10 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
             callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
 			callbacks.prev = () => callbacks.atIndex((indexRef.current + length - 1) % length);
         }
+    
+    return () => {
+      clearTimeout(timeoutHandleRef.current);
+    }
 	}
 	 
 	// Runs once after DOM is loaded; effectively `componentDidMount`	

--- a/src/index.js
+++ b/src/index.js
@@ -78,20 +78,20 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			);
 		} 
 	);
-    
-    const [timeoutHandle, setTimeoutHandle] = useState(0);
-    const timeoutHandleRef = useRef(timeoutHandle);
-    timeoutHandleRef.current = timeoutHandle;
-    const [index, setIndex] = useState(0);
-    const indexRef = useRef(index);
+		
+		const [timeoutHandle, setTimeoutHandle] = useState(0);
+		const timeoutHandleRef = useRef(timeoutHandle);
+		timeoutHandleRef.current = timeoutHandle;
+		const [index, setIndex] = useState(0);
+		const indexRef = useRef(index);
 	indexRef.current = index;
 	
 	if (callbacks) callbacks.getCount = () => imgs.length;
 
-  const clearAndSetTimeoutHandle = (newTimeoutHandle) => {
-    clearTimeout(timeoutHandleRef.current);
-    setTimeoutHandle(newTimeoutHandle);
-  }
+	const clearAndSetTimeoutHandle = (newTimeoutHandle) => {
+		clearTimeout(timeoutHandleRef.current);
+		setTimeoutHandle(newTimeoutHandle);
+	}
 
 	const initEffect = () => {
 		bgRefs.forEach((bgRef) => {
@@ -102,9 +102,9 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			subWrappers.push(subRef.current);
 		})
 		
-        const length = bgWrappers.length;
+				const length = bgWrappers.length;
 		const callback = function(){     
-            const index = indexRef.current;
+						const index = indexRef.current;
 			
 			bgWrappers[index].style.opacity = 0;
 			bgWrappers[(index + 1) % length].style.opacity = 1;
@@ -119,42 +119,42 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			{
 				callbacks.onChange(index, (index + 1) % length);
 			}
-            setIndex(prevIndex => (prevIndex + 1) % length);
-            clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
+						setIndex(prevIndex => (prevIndex + 1) % length);
+						clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
 		}
 
-        clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
+				clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
  
-        if (callbacks){     
-            callbacks.atIndex = function (newIndex) {
-                const index = indexRef.current;
-                clearTimeout(timeoutHandleRef.current);
-                    
-                bgWrappers[index].style.opacity = 0;
-                bgWrappers[(newIndex) % length].style.opacity = 1;
-        
-                subWrappers[index].style.opacity = 0;
-                subWrappers[index].style.pointerEvents = "none";
-                
-                subWrappers[(newIndex) % length].style.opacity = 1;
-                subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
+				if (callbacks){     
+						callbacks.atIndex = function (newIndex) {
+								const index = indexRef.current;
+								clearTimeout(timeoutHandleRef.current);
+										
+								bgWrappers[index].style.opacity = 0;
+								bgWrappers[(newIndex) % length].style.opacity = 1;
+				
+								subWrappers[index].style.opacity = 0;
+								subWrappers[index].style.pointerEvents = "none";
+								
+								subWrappers[(newIndex) % length].style.opacity = 1;
+								subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
 				
 				
 				if(callbacks.onChange) 
 				{
 					callbacks.onChange(index, newIndex % length);
 				}
-                setIndex((newIndex) % length);
-                clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
-            }
+								setIndex((newIndex) % length);
+								clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
+						}
 
-            callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
+						callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
 			callbacks.prev = () => callbacks.atIndex((indexRef.current + length - 1) % length);
-        }
-    
-    return () => {
-      clearTimeout(timeoutHandleRef.current);
-    }
+				}
+		
+		return () => {
+			clearTimeout(timeoutHandleRef.current);
+		}
 	}
 	 
 	// Runs once after DOM is loaded; effectively `componentDidMount`	

--- a/src/index.js
+++ b/src/index.js
@@ -103,47 +103,36 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 		})
 		
 		const length = bgWrappers.length;
-		const callback = function(){     
+
+		const changeIndex = function (newIndex) {
 			const index = indexRef.current;
-			
+			clearTimeout(timeoutHandleRef.current);
+					
 			bgWrappers[index].style.opacity = 0;
-			bgWrappers[(index + 1) % length].style.opacity = 1;
+			bgWrappers[(newIndex) % length].style.opacity = 1;
 
 			subWrappers[index].style.opacity = 0;
 			subWrappers[index].style.pointerEvents = "none";
 			
-			subWrappers[(index + 1) % length].style.opacity = 1;
-			subWrappers[(index + 1) % length].style.pointerEvents = "auto";					
-			
-			if(callbacks && callbacks.onChange){
-				callbacks.onChange(index, (index + 1) % length);
+			subWrappers[(newIndex) % length].style.opacity = 1;
+			subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
+	
+			if(callbacks.onChange){
+				callbacks.onChange(index, newIndex % length);
 			}
-			setIndex(prevIndex => (prevIndex + 1) % length);
-			clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));
+			setIndex((newIndex) % length);
+			clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
+		}
+
+		const callback = function(){
+			const index = indexRef.current;
+			changeIndex(index + 1)
 		}
 
 		clearAndSetTimeoutHandle(setTimeout(callback, initDelay * 1000));
  
 		if (callbacks){     
-			callbacks.atIndex = function (newIndex) {
-				const index = indexRef.current;
-				clearTimeout(timeoutHandleRef.current);
-						
-				bgWrappers[index].style.opacity = 0;
-				bgWrappers[(newIndex) % length].style.opacity = 1;
-
-				subWrappers[index].style.opacity = 0;
-				subWrappers[index].style.pointerEvents = "none";
-				
-				subWrappers[(newIndex) % length].style.opacity = 1;
-				subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
-		
-				if(callbacks.onChange){
-					callbacks.onChange(index, newIndex % length);
-				}
-				setIndex((newIndex) % length);
-				clearAndSetTimeoutHandle(setTimeout(callback, duration * 1000));        
-			}
+			callbacks.atIndex = changeIndex
 
 			callbacks.next = () => callbacks.atIndex((indexRef.current + 1) % length);
 			callbacks.prev = () => callbacks.atIndex((indexRef.current + length - 1) % length);


### PR DESCRIPTION
The background slider continues to fire after the background has been unmounted.  Largely this is down to the timeout not being cleared in a returned cleanup function from the useEffect hook (see 1st commit).  Also, when used in combination with a pagination component, this causes errors as the existing referenced timeout is reset without first clearing it (see 2nd commit).  I noticed that the code is largely duplicated for jumping to a specific index via pagination callbacks or using the default rolling forwards change.  I cleaned up (3rd and 4th commit) and then dryed up the code (5th commit) there too.
