### PR TITLE
bug - Placing a conditional on a method not a variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 			subWrappers[(newIndex) % length].style.opacity = 1;
 			subWrappers[(newIndex) % length].style.pointerEvents = "auto";					
 	
-			if(callbacks.onChange){
+			if(callbacks){
 				callbacks.onChange(index, newIndex % length);
 			}
 			setIndex((newIndex) % length);


### PR DESCRIPTION
Placing a conditional on a method not a variable. This is causing the plugin to crash on change