### PR TITLE
Gatsby v3 / gatsby-plugin-image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const Layout = ({ children }) => (
             nodes {
               relativePath
               childImageSharp {
-                gatsbyImageData(width: 4000, quality: 100, layout: CONSTRAINED)
+                gatsbyImageData(width: 4000, quality: 100)
               }
             }
           }
@@ -73,7 +73,7 @@ const Layout = ({ children }) => (
             nodes {
               relativePath
               childImageSharp {
-                gatsbyImageData(width: 4000, quality: 100, layout: CONSTRAINED)
+                gatsbyImageData(width: 4000, quality: 100)
               }
             }
           }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-image-background-slider
 
-> Lazy-loaded background images, with a simple fade transition between them, using [`gatsby-image`](https://www.npmjs.com/package/gatsby-image). Inspired by [`react-background-slider`](https://www.npmjs.com/package/react-background-slider), except for—well—the obvious.
+> Lazy-loaded background images, with a simple fade transition between them, using [`gatsby-plugin-image`](https://www.npmjs.com/package/gatsby-image). Inspired by [`react-background-slider`](https://www.npmjs.com/package/react-background-slider), except for—well—the obvious.
 
 [![NPM](https://img.shields.io/npm/v/gatsby-image-background-slider.svg)](https://www.npmjs.com/package/gatsby-image-background-slider) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
@@ -33,9 +33,7 @@ const Layout = ({ children }) => (
             nodes {
               relativePath
               childImageSharp {
-                fluid (maxWidth: 4000, quality: 100){
-                  ...GatsbyImageSharpFluid
-                }
+                gatsbyImageData(width: 4000, quality: 100, layout: CONSTRAINED)
               }
             }
           }
@@ -75,9 +73,7 @@ const Layout = ({ children }) => (
             nodes {
               relativePath
               childImageSharp {
-                fluid (maxWidth: 4000, quality: 100){
-                  ...GatsbyImageSharpFluid
-                }
+                gatsbyImageData(width: 4000, quality: 100, layout: CONSTRAINED)
               }
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6325,7 +6325,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6346,12 +6347,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6366,17 +6369,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6493,7 +6499,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6505,6 +6512,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6519,6 +6527,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6526,12 +6535,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6550,6 +6561,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6630,7 +6642,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6642,6 +6655,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6727,7 +6741,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6763,6 +6778,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6782,6 +6798,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6825,12 +6842,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "prop-types": "^15.5.4",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "gatsby": "^2.0.0",
-    "gatsby-image": "^2.0.0",
-    "gatsby-plugin-sharp": "^2.0.0",
-    "gatsby-source-filesystem": "^2.0.0",
-    "gatsby-transformer-sharp": "^2.0.0"
+    "gatsby": "^3.0.0",
+    "gatsby-plugin-image": "^1.0.0",
+    "gatsby-plugin-sharp": "^3.0.0",
+    "gatsby-source-filesystem": "^3.0.0",
+    "gatsby-transformer-sharp": "^3.0.0"
   },
   "devDependencies": {
     "@svgr/rollup": "^2.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
-import Img from "gatsby-image"
+import { GatsbyImage } from 'gatsby-plugin-image'
 
 /**
  * @param {object} props Component props
@@ -47,7 +47,7 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 	}
 	
 	const imgs = nodes.map(
-		(data, index)=>{			
+		(data, index)=>{
 			const backgroundStyle = {
 				position:"absolute", 
 				zIndex: -10,
@@ -72,7 +72,7 @@ const BackgroundSlider = ({callbacks, images, duration, transition, initDelay, q
 
 			return (
 				<React.Fragment key={index}>
-					<div ref={bgRefs[index]}><Img fluid={data.childImageSharp.fluid} style={{...backgroundStyle, ...style}} {...imageProps}/></div>
+					<div ref={bgRefs[index]}><GatsbyImage image={data.childImageSharp.gatsbyImageData} style={{...backgroundStyle, ...style}} {...imageProps}/></div>
 					<div ref={subRefs[index]} style={subStyle}>{React.Children.toArray(children)[index]}</div>
 				</React.Fragment>
 			);


### PR DESCRIPTION
Should probably merge into a seperate branch and will need to sort out versioning, but I tested this and it appears to work. You might want to tweak the behavior with alt tags, since they're now required otherwise you'll get errors in the dev server, but this is the base implementation on the new gatsby-plugin-image.